### PR TITLE
feat: loader libraries configurable as GoogleMap component prop

### DIFF
--- a/src/components/GoogleMap.vue
+++ b/src/components/GoogleMap.vue
@@ -26,6 +26,7 @@ import { MapSymbol, ApiSymbol, mapEvents } from '../shared/index';
 export default defineComponent({
   props: {
     apiKey: { type: String, default: '' },
+    libraries: Array as PropType<('drawing' | 'geometry' | 'localContext' | 'places' | 'visualization')[]>,
     region: String,
     language: String,
     backgroundColor: String,
@@ -159,7 +160,7 @@ export default defineComponent({
       const loader = new Loader({
         apiKey: props.apiKey,
         version: 'weekly',
-        libraries: ['places'],
+        libraries: props.libraries || ['places'],
         language: props.language,
         region: props.region,
       });


### PR DESCRIPTION
Currently the libraries loaded are hardcoded in the GoogleMap component, this PR would expose a property called `libraries` which if set would override the default.

This should not change anything for current users.
I successfully tested this using npm link.

Closes #24 