### PR TITLE
fix: prevent marker flickering

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -13,6 +13,11 @@ export default defineComponent({
     const greet = () => alert("hi");
     const dist = ref(0);
     const testControlPosition = ref("LEFT_CENTER");
+    const markers = ref([
+      { position: { lat: 35 + 0.015, lng: -95 + 0.015 } },
+      { position: { lat: 35 + 0.005, lng: -95 + 0.005 } },
+    ]);
+    const remove = () => (markers.value = []);
 
     setInterval(() => {
       dist.value += 0.005;
@@ -22,10 +27,18 @@ export default defineComponent({
       testControlPosition.value = testControlPosition.value === "LEFT_CENTER" ? "RIGHT_CENTER" : "LEFT_CENTER";
     }, 3000);
 
+    setInterval(() => {
+      // test blinking
+      markers.value = [
+        { position: { lat: 35 + 0.015, lng: -95 + 0.015 } },
+        { position: { lat: 35 + 0.005, lng: -95 + 0.005 } },
+      ];
+    }, 1000);
+
     // Just to test dynamic custom controls
     const bottomControlQuantity = ref(0);
 
-    return { greet, dist, bottomControlQuantity, testControlPosition };
+    return { greet, remove, markers, dist, bottomControlQuantity, testControlPosition };
   },
 });
 </script>
@@ -34,7 +47,7 @@ export default defineComponent({
   <GoogleMap api-key="" style="width: 100%; height: 80vh" :center="{ lat: 35, lng: -95 }" :zoom="13">
     <Marker :options="{ position: { lat: 35, lng: -95 + dist } }" />
     <Marker :options="{ position: { lat: 35, lng: -95 } }" @click="greet" />
-
+    <Marker v-for="(marker, index) of markers" :key="index" :options="marker" @click="remove" />
     <CustomControl v-for="index in parseInt(bottomControlQuantity)" :key="`control-${index}`" position="BOTTOM_CENTER">
       <button style="height: 20px; background: orange; color: white" @click="greet">[{{ index }}] Greet</button>
     </CustomControl>


### PR DESCRIPTION
This PR closes #17 by only removing markers when the component is destroy, and changing options when options change (rather than re-rendering)