### PR TITLE
Optimize CustomMarkerClass draw Method

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -63,52 +63,51 @@ export function createCustomMarkerClass(api: typeof google.maps): ICustomMarkerC
 
       if (point) {
         this.element.style.position = "absolute";
-        const height = this.element.offsetHeight;
-        const width = this.element.offsetWidth;
-        let x: number, y: number;
+        let transformX: string, transformY: string;
+
         switch (this.opts.anchorPoint) {
           case "TOP_CENTER":
-            x = point.x - width / 2;
-            y = point.y;
+            transformX = "-50%";
+            transformY = "-100%";
             break;
           case "BOTTOM_CENTER":
-            x = point.x - width / 2;
-            y = point.y - height;
+            transformX = "-50%";
+            transformY = "0";
             break;
           case "LEFT_CENTER":
-            x = point.x;
-            y = point.y - height / 2;
+            transformX = "-100%";
+            transformY = "-50%";
             break;
           case "RIGHT_CENTER":
-            x = point.x - width;
-            y = point.y - height / 2;
+            transformX = "0";
+            transformY = "-50%";
             break;
           case "TOP_LEFT":
-            x = point.x;
-            y = point.y;
+            transformX = "-100%";
+            transformY = "-100%";
             break;
           case "TOP_RIGHT":
-            x = point.x - width;
-            y = point.y;
+            transformX = "0";
+            transformY = "-100%";
             break;
           case "BOTTOM_LEFT":
-            x = point.x;
-            y = point.y - height;
+            transformX = "-100%";
+            transformY = "0";
             break;
           case "BOTTOM_RIGHT":
-            x = point.x - width;
-            y = point.y - height;
+            transformX = "0";
+            transformY = "0";
             break;
           default:
             // "center"
-            x = point.x - width / 2;
-            y = point.y - height / 2;
+            transformX = "-50%";
+            transformY = "-50%";
         }
 
-        this.element.style.left = x + "px";
-        this.element.style.top = y + "px";
+        this.element.style.left = point.x + (this.opts.offsetX || 0) + "px";
+        this.element.style.top = point.y + (this.opts.offsetY || 0) + "px";
         // eslint-disable-next-line prettier/prettier
-        this.element.style.transform = `translateX(${this.opts.offsetX || 0}px) translateY(${this.opts.offsetY || 0}px)`;
+        this.element.style.transform = `translateX(${transformX}) translateY(${transformY})`;
 
         if (this.opts.zIndex) {
           this.element.style.zIndex = this.opts.zIndex.toString();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -104,10 +104,10 @@ export function createCustomMarkerClass(api: typeof google.maps): ICustomMarkerC
             transformY = "-50%";
         }
 
-        this.element.style.left = point.x + (this.opts.offsetX || 0) + "px";
-        this.element.style.top = point.y + (this.opts.offsetY || 0) + "px";
+        const xPos = point.x + (this.opts.offsetX || 0) + "px";
+        const yPos = point.y + (this.opts.offsetY || 0) + "px";
         // eslint-disable-next-line prettier/prettier
-        this.element.style.transform = `translateX(${transformX}) translateY(${transformY})`;
+        this.element.style.transform = `translateX(${transformX}) translateX(${xPos}) translateY(${transformY}) translateY(${yPos})`;
 
         if (this.opts.zIndex) {
           this.element.style.zIndex = this.opts.zIndex.toString();


### PR DESCRIPTION
Context on the issue: https://github.com/inocan-group/vue3-google-map/issues/90 and https://github.com/inocan-group/vue3-google-map/issues/162

Changes:

Forced redraw is a result of the following causing significant lag while zooming:

```
const height = this.element.offsetHeight;
const width = this.element.offsetWidth;
```

Instead of getting the width and height of a given element, we can use CSS transforms to position marker based on its already calculated width. When using `position: absolute; top: x, left: x` - we can also assume that the item is being positioned in the bottom right corner of a given marker (thus making repositioning easier).

If we want to continue to use the offsetX and offsetY optional configuration, just add it to point.x and point.y instead.


Result:
I've only been able to test locally, but I more or less have completely removed the lag associated with zooming on 500+ CustomMarkers. Looking for someone to help me validate.
