### PR TITLE
#289 Update types and add missing colorScheme prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "pnpm": "^8.7.6",
-    "@types/google.maps": "^3.53.6",
+    "@types/google.maps": "^3.58.1",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "@vitejs/plugin-vue": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ dependencies:
 
 devDependencies:
   '@types/google.maps':
-    specifier: ^3.53.6
-    version: 3.53.6
+    specifier: ^3.58.1
+    version: 3.58.1
   '@typescript-eslint/eslint-plugin':
     specifier: ^4.33.0
     version: 4.33.0(@typescript-eslint/parser@4.33.0)(eslint@7.32.0)(typescript@5.4.5)
@@ -925,8 +925,8 @@ packages:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
-  /@types/google.maps@3.53.6:
-    resolution: {integrity: sha512-zDU8c7K0YR1Ob7Wn0qCSQvICIuxilZH9KFIDHK6JO/5QzqEMv8e4+9bmyoDEktA9vPNmwP++zzg65h9y53iZ6Q==}
+  /@types/google.maps@3.58.1:
+    resolution: {integrity: sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==}
     dev: true
 
   /@types/json-schema@7.0.12:

--- a/src/components/GoogleMap.vue
+++ b/src/components/GoogleMap.vue
@@ -70,6 +70,10 @@ export default defineComponent({
       required: false,
       default: undefined,
     },
+    colorScheme: {
+      type: String as PropType<google.maps.ColorScheme>,
+      required: false,
+    },
     controlSize: {
       type: Number,
       required: false,

--- a/src/components/GoogleMap.vue
+++ b/src/components/GoogleMap.vue
@@ -71,7 +71,7 @@ export default defineComponent({
       default: undefined,
     },
     colorScheme: {
-      type: String as PropType<google.maps.ColorScheme>,
+      type: String as PropType<keyof typeof google.maps.ColorScheme>,
       required: false,
     },
     controlSize: {


### PR DESCRIPTION
Issue #289 - Updates @types/google.maps and adds a new prop for [ColorScheme](https://developers.google.com/maps/documentation/javascript/mapcolorscheme).