### PR TITLE
fix(HeatmapLayer): support reactive data updates

### DIFF
--- a/src/components/HeatmapLayer.ts
+++ b/src/components/HeatmapLayer.ts
@@ -27,12 +27,12 @@ export default defineComponent({
         const hasChanged = !equal(options, oldOptions) || map.value !== oldMap;
 
         if (map.value && api.value && hasChanged) {
-          const opts: ExtendedHeatmapLayerOptions = structuredClone(options);
+          let opts: HeatmapLayerOptions;
 
-          if (opts.data && !(opts.data instanceof api.value.MVCArray)) {
+          if (options.data && !(options.data instanceof api.value.MVCArray)) {
             const LatLng = api.value.LatLng;
 
-            opts.data = opts.data?.map((point) => {
+            const transformedData = options.data.map((point) => {
               if (
                 point instanceof LatLng ||
                 ("location" in point && (point.location instanceof LatLng || point.location === null))
@@ -46,16 +46,25 @@ export default defineComponent({
                 return new LatLng(point);
               }
             }) as HeatmapLayerOptions["data"];
+
+            // Create new options object with transformed data
+            opts = {
+              ...options,
+              data: transformedData,
+            };
+          } else {
+            // Use options as-is when no transformation needed
+            opts = options as HeatmapLayerOptions;
           }
 
           if (heatmapLayer.value) {
-            heatmapLayer.value.setOptions(opts as HeatmapLayerOptions);
+            heatmapLayer.value.setOptions(opts);
           } else {
             heatmapLayer.value = markRaw(
               new api.value.visualization.HeatmapLayer({
                 ...opts,
                 map: map.value,
-              } as HeatmapLayerOptions)
+              })
             );
           }
         }


### PR DESCRIPTION
- Remove structuredClone to fix DataCloneError with Vue reactive objects
- Create new options object only when data transformation is needed
- Preserve reactivity by avoiding deep cloning of proxy objects
- Maintain backward compatibility with all existing data formats

Fixes #318, #269

🤖 Generated with [Claude Code](https://claude.ai/code)