### PR TITLE
fix(AdvancedMarker): resolve race condition with slot content rendering

### DIFF
--- a/src/components/AdvancedMarker.vue
+++ b/src/components/AdvancedMarker.vue
@@ -57,12 +57,16 @@ export default defineComponent({
     );
 
     watch(
-      [map, options, pinOptions],
-      async (_, [oldMap, oldOptions, oldPinOptions]) => {
+      [map, options, pinOptions, markerRef],
+      async (_, [oldMap, oldOptions, oldPinOptions, oldMarkerRef]) => {
         const hasOptionChange = !equal(options.value, oldOptions) || !equal(pinOptions.value, oldPinOptions);
-        const hasChanged = hasOptionChange || map.value !== oldMap;
+        const hasMarkerRefChange = markerRef.value !== oldMarkerRef;
+        const hasChanged = hasOptionChange || hasMarkerRefChange || map.value !== oldMap;
 
         if (!map.value || !api.value || !hasChanged) return;
+
+        // If we need custom slot content but markerRef isn't available yet, wait for it
+        if (hasCustomSlotContent.value && !markerRef.value) return;
 
         const { AdvancedMarkerElement, PinElement } = api.value.marker;
 
@@ -104,6 +108,7 @@ export default defineComponent({
       },
       {
         immediate: true,
+        flush: "post", // Ensure DOM updates happen before this watcher runs
       }
     );
 


### PR DESCRIPTION
Fixed timing issue where AdvancedMarker components with custom slot content would not render correctly on initial load due to template refs being undefined when the watcher ran with immediate: true.

Changes:
- Add markerRef as watcher dependency to properly track template ref changes
- Add guard clause to wait for markerRef when custom slot content is used
- Add flush: 'post' to ensure DOM updates complete before watcher execution
- Track markerRefChange to trigger updates when template ref becomes available

Fixes rendering issues where:
- AdvancedMarkers appeared as regular Markers until re-renders occurred
- Custom slot content was ignored on initial component mount
- Users needed workarounds like dummy markers to trigger proper rendering

Related to GitHub issue #322.

🤖 Generated with [Claude Code](https://claude.ai/code)