### PR TITLE
Upgrade js-api-loader to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@googlemaps/js-api-loader": "^1.16.2",
+    "@googlemaps/js-api-loader": "^2.0.1",
     "@googlemaps/markerclusterer": "^2.4.0",
     "fast-deep-equal": "^3.1.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@googlemaps/js-api-loader':
-        specifier: ^1.16.2
-        version: 1.16.10
+        specifier: ^2.0.1
+        version: 2.0.1
       '@googlemaps/markerclusterer':
         specifier: ^2.4.0
         version: 2.6.2
@@ -686,8 +686,8 @@ packages:
   '@googlemaps/jest-mocks@2.22.6':
     resolution: {integrity: sha512-t3n0l03OdGPEUCfWVC1a4xGgcE21+58tGdNsIjGWsTbsaMZBOfCxwTHvzmAx/H0dyPeKZ4uWmtahsyUQIcGInA==}
 
-  '@googlemaps/js-api-loader@1.16.10':
-    resolution: {integrity: sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==}
+  '@googlemaps/js-api-loader@2.0.1':
+    resolution: {integrity: sha512-YUtKJSWH6FiE/6Ii+NP+WfkvoZ55DLwyqthKmVYxZZwn/ny310dvz9Zw3cO1besEhGxA9lW7Ctjmzae1putjXQ==}
 
   '@googlemaps/markerclusterer@2.6.2':
     resolution: {integrity: sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==}
@@ -4195,7 +4195,9 @@ snapshots:
 
   '@googlemaps/jest-mocks@2.22.6': {}
 
-  '@googlemaps/js-api-loader@1.16.10': {}
+  '@googlemaps/js-api-loader@2.0.1':
+    dependencies:
+      '@types/google.maps': 3.58.1
 
   '@googlemaps/markerclusterer@2.6.2':
     dependencies:


### PR DESCRIPTION
A new major version for [js-api-loader](https://github.com/googlemaps/js-api-loader) (V2) was released.
Following it's [migration guide](https://github.com/googlemaps/js-api-loader/blob/main/MIGRATION.md) I've made the required changes in `vue3-google-map` to use this new version.