### PR TITLE
Optimization render of cluster markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,30 @@ const locations = [
 
 You can listen for [the following events](https://googlemaps.github.io/js-markerclusterer/enums/MarkerClustererEvents.html) on the `MarkerCluster` component.
 
+#### Performance Optimization
+
+MarkerCluster uses debounced rendering to improve performance when adding or removing markers. Instead of rendering after every marker operation, it batches multiple operations together and renders once after a short delay.
+
+The `renderDebounceDelay` prop controls the debounce delay in milliseconds (default: `10`). For immediate rendering, access the underlying clusterer via a template ref and call `render()`:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const clusterRef = ref()
+
+function forceRender() {
+  clusterRef.value?.markerCluster?.render()
+}
+</script>
+
+<template>
+  <MarkerCluster ref="clusterRef">
+    <!-- markers -->
+  </MarkerCluster>
+</template>
+```
+
 ### Heatmap Layer
 
 > [!WARNING]

--- a/docs/components/marker-cluster.md
+++ b/docs/components/marker-cluster.md
@@ -113,3 +113,27 @@ const locations = [
 ## Events
 
 You can listen for [the following events](https://googlemaps.github.io/js-markerclusterer/enums/MarkerClustererEvents.html) on the `MarkerCluster` component.
+
+## Performance Optimization
+
+MarkerCluster uses debounced rendering to improve performance when adding or removing markers. Instead of rendering after every marker operation, it batches multiple operations together and renders once after a short delay.
+
+The `renderDebounceDelay` prop controls the debounce delay in milliseconds (default: `10`). For immediate rendering, access the underlying clusterer via a template ref and call `render()`:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+
+const clusterRef = ref()
+
+function forceRender() {
+  clusterRef.value?.markerCluster?.render()
+}
+</script>
+
+<template>
+  <MarkerCluster ref="clusterRef">
+    <!-- markers -->
+  </MarkerCluster>
+</template>
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,6 @@ module.exports = {
     "!src/**/__tests__/**",
     "!src/shims-*.ts",
     "!src/themes/**",
-    "!src/components/DebouncedMarkerClusterer.ts",
   ],
   coverageThreshold: {
     global: {
@@ -43,7 +42,7 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   // Ignore certain files
-  transformIgnorePatterns: ["node_modules/(?!@googlemaps/)"],
+  transformIgnorePatterns: ["node_modules/(?!(@googlemaps|lodash-es)/)"],
   testEnvironmentOptions: {
     customExportConditions: ["node", "node-addons"],
   },

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,0 @@
-[tools]
-node = "20"
-pnpm = "10"

--- a/package.json
+++ b/package.json
@@ -57,14 +57,15 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.0.1",
     "@googlemaps/markerclusterer": "^2.4.0",
-    "debounce": "^2.2.0",
-    "fast-deep-equal": "^3.1.3"
+    "fast-deep-equal": "^3.1.3",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@googlemaps/jest-mocks": "^2.22.6",
     "@types/google.maps": "^3.58.1",
     "@types/jest": "^29.5.14",
+    "@types/lodash-es": "^4.17.12",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "@vitejs/plugin-vue": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,12 @@ importers:
       '@googlemaps/markerclusterer':
         specifier: ^2.4.0
         version: 2.6.2
-      debounce:
-        specifier: ^2.2.0
-        version: 2.2.0
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@babel/core':
         specifier: ^7.28.0
@@ -33,6 +33,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^4.33.0
         version: 4.33.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.8.3))(eslint@7.32.0)(typescript@5.8.3)
@@ -1028,6 +1031,12 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
 
@@ -1684,10 +1693,6 @@ packages:
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
-
-  debounce@2.2.0:
-    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
-    engines: {node: '>=18'}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -2593,6 +2598,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
@@ -4660,6 +4668,12 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.20
+
+  '@types/lodash@4.17.20': {}
+
   '@types/markdown-it@14.1.2':
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -5429,8 +5443,6 @@ snapshots:
   dateformat@3.0.3: {}
 
   de-indent@1.0.2: {}
-
-  debounce@2.2.0: {}
 
   debug@4.4.1:
     dependencies:
@@ -6617,6 +6629,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.ismatch@4.4.0: {}
 

--- a/src/components/__tests__/DebouncedMarkerClusterer.spec.ts
+++ b/src/components/__tests__/DebouncedMarkerClusterer.spec.ts
@@ -1,0 +1,121 @@
+import debounce from "lodash-es/debounce";
+import { DebouncedMarkerClusterer } from "../DebouncedMarkerClusterer";
+
+const DEFAULT_DEBOUNCE_DELAY = 10;
+
+const mockAddMarker = jest.fn();
+const mockRemoveMarker = jest.fn();
+const mockAddMarkers = jest.fn();
+const mockRemoveMarkers = jest.fn();
+const mockClearMarkers = jest.fn();
+const mockRender = jest.fn();
+
+jest.mock("@googlemaps/markerclusterer", () => {
+  return {
+    MarkerClusterer: class {
+      addMarker(marker: unknown, noDraw?: boolean) {
+        mockAddMarker(marker, noDraw);
+      }
+      removeMarker(marker: unknown, noDraw?: boolean) {
+        return mockRemoveMarker(marker, noDraw);
+      }
+      addMarkers(markers: unknown[], noDraw?: boolean) {
+        mockAddMarkers(markers, noDraw);
+      }
+      removeMarkers(markers: unknown[], noDraw?: boolean) {
+        return mockRemoveMarkers(markers, noDraw);
+      }
+      clearMarkers(noDraw?: boolean) {
+        mockClearMarkers(noDraw);
+      }
+      render() {
+        mockRender();
+      }
+    },
+  };
+});
+
+const mockDebouncedRender = Object.assign(jest.fn(), { cancel: jest.fn() });
+
+jest.mock("lodash-es/debounce", () => {
+  return jest.fn(() => mockDebouncedRender);
+});
+
+describe("DebouncedMarkerClusterer", () => {
+  let clusterer: DebouncedMarkerClusterer;
+  let mockMarker: google.maps.marker.AdvancedMarkerElement;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMarker = {} as google.maps.marker.AdvancedMarkerElement;
+    clusterer = new DebouncedMarkerClusterer({ map: {} as google.maps.Map }, DEFAULT_DEBOUNCE_DELAY);
+  });
+
+  describe("Instance Creation", () => {
+    it("should create debounced render with correct delay and options", () => {
+      expect(debounce).toHaveBeenCalledWith(expect.any(Function), DEFAULT_DEBOUNCE_DELAY, {
+        leading: true,
+        trailing: true,
+      });
+    });
+
+    it("should use custom delay when provided", () => {
+      new DebouncedMarkerClusterer({ map: {} as google.maps.Map }, 50);
+
+      expect(debounce).toHaveBeenCalledWith(expect.any(Function), 50, { leading: true, trailing: true });
+    });
+  });
+
+  describe("Marker Operations", () => {
+    it("should pass noDraw=true to parent and call debounced render", () => {
+      clusterer.addMarker(mockMarker);
+
+      expect(mockAddMarker).toHaveBeenCalledWith(mockMarker, true);
+      expect(mockDebouncedRender).toHaveBeenCalled();
+    });
+
+    it("should not call debounced render when noDraw=true", () => {
+      clusterer.addMarker(mockMarker, true);
+
+      expect(mockAddMarker).toHaveBeenCalledWith(mockMarker, true);
+      expect(mockDebouncedRender).not.toHaveBeenCalled();
+    });
+
+    it("should call debounced render for all marker operations", () => {
+      clusterer.addMarker(mockMarker);
+      clusterer.removeMarker(mockMarker);
+      clusterer.addMarkers([mockMarker]);
+      clusterer.removeMarkers([mockMarker]);
+      clusterer.clearMarkers();
+
+      expect(mockDebouncedRender).toHaveBeenCalledTimes(5);
+    });
+
+    it("should return result from parent for remove operations", () => {
+      mockRemoveMarker.mockReturnValue(true);
+      mockRemoveMarkers.mockReturnValue(false);
+
+      expect(clusterer.removeMarker(mockMarker)).toBe(true);
+      expect(clusterer.removeMarkers([mockMarker])).toBe(false);
+    });
+  });
+
+  describe("render()", () => {
+    it("should cancel pending debounced render and render immediately", () => {
+      clusterer.render();
+
+      expect(mockDebouncedRender.cancel).toHaveBeenCalled();
+      expect(mockDebouncedRender).not.toHaveBeenCalled();
+      expect(mockRender).toHaveBeenCalled();
+    });
+  });
+
+  describe("destroy()", () => {
+    it("should cancel pending debounced render", () => {
+      clusterer.destroy();
+
+      expect(mockDebouncedRender.cancel).toHaveBeenCalled();
+      expect(mockRender).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
The error is caused by the fact that every time a marker is added or removed, the cluster render is triggered, which negatively impacts performance and may even freeze the browser tab.

This adds debounce for rendering markers in the cluster, which fixes performance issues. It may close issue https://github.com/inocan-group/vue3-google-map/issues/305. I'm not sure what the timeout for debounce should be, but with the current value, I haven't noticed any issues. Just in case, I added a prop for configuration.