### PR TITLE
fix: add SafeSuperClusterViewportAlgorithm to handle empty markers

### DIFF
--- a/src/components/MarkerCluster.ts
+++ b/src/components/MarkerCluster.ts
@@ -1,11 +1,8 @@
 import { defineComponent, PropType, ref, provide, inject, watch, markRaw, onBeforeUnmount, type Ref } from "vue";
-import {
-  MarkerClustererOptions,
-  MarkerClustererEvents,
-  SuperClusterViewportAlgorithm,
-} from "@googlemaps/markerclusterer";
+import { MarkerClustererOptions, MarkerClustererEvents } from "@googlemaps/markerclusterer";
 import { mapSymbol, apiSymbol, markerClusterSymbol } from "../shared/index";
 import { DebouncedMarkerClusterer } from "./DebouncedMarkerClusterer";
+import { SafeSuperClusterViewportAlgorithm } from "./SafeSuperClusterViewportAlgorithm";
 
 export interface IMarkerClusterExposed {
   markerCluster: Ref<DebouncedMarkerClusterer | undefined>;
@@ -43,7 +40,7 @@ export default defineComponent({
                 map: map.value,
                 // Better perf than the default `SuperClusterAlgorithm`. See:
                 // https://github.com/googlemaps/js-markerclusterer/pull/640
-                algorithm: new SuperClusterViewportAlgorithm(props.options.algorithmOptions ?? {}),
+                algorithm: new SafeSuperClusterViewportAlgorithm(props.options.algorithmOptions ?? {}),
                 ...props.options,
               },
               props.renderDebounceDelay

--- a/src/components/SafeSuperClusterViewportAlgorithm.ts
+++ b/src/components/SafeSuperClusterViewportAlgorithm.ts
@@ -1,0 +1,25 @@
+import { SuperClusterViewportAlgorithm, type AlgorithmInput, type AlgorithmOutput } from "@googlemaps/markerclusterer";
+
+/**
+ * Wrapper around SuperClusterViewportAlgorithm that handles empty marker arrays.
+ *
+ * Stopgap for upstream issue googlemaps/js-markerclusterer#1129.
+ * The fix from PR #1014 was only applied to SuperClusterAlgorithm, not
+ * SuperClusterViewportAlgorithm. This wrapper adds the same empty markers check.
+ *
+ * @see https://github.com/googlemaps/js-markerclusterer/issues/1129
+ * @see https://github.com/googlemaps/js-markerclusterer/pull/1130
+ *
+ * TODO: Remove once upstream PR #1130 is released.
+ */
+export class SafeSuperClusterViewportAlgorithm extends SuperClusterViewportAlgorithm {
+  calculate(input: AlgorithmInput): AlgorithmOutput {
+    // Early return for empty markers - prevents "Cannot read properties of
+    // undefined (reading 'range')" error when supercluster.getClusters() is
+    // called before load() has initialized the internal KD-tree.
+    if (input.markers.length === 0) {
+      return { clusters: [], changed: true };
+    }
+    return super.calculate(input);
+  }
+}

--- a/src/components/__tests__/MarkerCluster.spec.ts
+++ b/src/components/__tests__/MarkerCluster.spec.ts
@@ -12,6 +12,7 @@ import {
 // Mock registry
 let mockMarkerClustererInstances: any[] = [];
 let createMarkerClustererSpy: jest.Mock | undefined;
+let createSafeSuperClusterViewportAlgorithmSpy: jest.Mock | undefined;
 
 jest.mock("../DebouncedMarkerClusterer", () => {
   return {
@@ -29,13 +30,22 @@ jest.mock("../DebouncedMarkerClusterer", () => {
   };
 });
 
+jest.mock("../SafeSuperClusterViewportAlgorithm", () => {
+  const { SuperClusterViewportAlgorithm } = jest.requireActual("@googlemaps/markerclusterer");
+
+  return {
+    SafeSuperClusterViewportAlgorithm: class extends SuperClusterViewportAlgorithm {
+      constructor(options: SuperClusterViewportOptions) {
+        createSafeSuperClusterViewportAlgorithmSpy?.(options);
+        super(options);
+      }
+    },
+  };
+});
+
 describe("MarkerCluster Component", () => {
   let mockMap: google.maps.Map;
   let mockApi: typeof google.maps;
-  let createSuperClusterViewportAlgorithmSpy: jest.Mock<
-    void,
-    ConstructorParameters<typeof SuperClusterViewportAlgorithm>
-  >;
 
   beforeEach(() => {
     // Reset mocks before each test
@@ -45,14 +55,7 @@ describe("MarkerCluster Component", () => {
     mockMap = new Map(null);
 
     createMarkerClustererSpy = jest.fn();
-    createSuperClusterViewportAlgorithmSpy = jest.fn();
-
-    (SuperClusterViewportAlgorithm as any) = class extends SuperClusterViewportAlgorithm {
-      constructor(options: SuperClusterViewportOptions) {
-        createSuperClusterViewportAlgorithmSpy(options);
-        super(options);
-      }
-    };
+    createSafeSuperClusterViewportAlgorithmSpy = jest.fn();
   });
 
   const getMarkerClustererMocks = () => mockMarkerClustererInstances;
@@ -72,7 +75,7 @@ describe("MarkerCluster Component", () => {
   };
 
   describe("Instance Creation", () => {
-    it("should create MarkerClusterer with SuperClusterViewportAlgorithm as default", async () => {
+    it("should create MarkerClusterer with SafeSuperClusterViewportAlgorithm as default", async () => {
       expect(getMarkerClustererMocks()).toHaveLength(0);
 
       createWrapper();
@@ -103,19 +106,19 @@ describe("MarkerCluster Component", () => {
       expect(getMarkerClustererMocks()).toHaveLength(0);
     });
 
-    it("should pass algorithmOptions to SuperClusterViewportAlgorithm", async () => {
+    it("should pass algorithmOptions to SafeSuperClusterViewportAlgorithm", async () => {
       const algorithmOptions = { maxZoom: 15 };
       createWrapper({ algorithmOptions });
       await nextTick();
 
-      expect(createSuperClusterViewportAlgorithmSpy).toHaveBeenCalledWith(algorithmOptions);
+      expect(createSafeSuperClusterViewportAlgorithmSpy).toHaveBeenCalledWith(algorithmOptions);
     });
 
     it("should use empty object as default algorithmOptions when not provided", async () => {
       createWrapper();
       await nextTick();
 
-      expect(createSuperClusterViewportAlgorithmSpy).toHaveBeenCalledWith({});
+      expect(createSafeSuperClusterViewportAlgorithmSpy).toHaveBeenCalledWith({});
     });
   });
 

--- a/src/components/__tests__/SafeSuperClusterViewportAlgorithm.spec.ts
+++ b/src/components/__tests__/SafeSuperClusterViewportAlgorithm.spec.ts
@@ -1,0 +1,54 @@
+import { SafeSuperClusterViewportAlgorithm } from "../SafeSuperClusterViewportAlgorithm";
+import type { AlgorithmInput } from "@googlemaps/markerclusterer";
+
+const mockSuperCalculate = jest.fn();
+
+jest.mock("@googlemaps/markerclusterer", () => {
+  return {
+    SuperClusterViewportAlgorithm: class {
+      calculate(input: AlgorithmInput) {
+        return mockSuperCalculate(input);
+      }
+    },
+  };
+});
+
+describe("SafeSuperClusterViewportAlgorithm", () => {
+  let algorithm: SafeSuperClusterViewportAlgorithm;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    algorithm = new SafeSuperClusterViewportAlgorithm({});
+  });
+
+  describe("calculate()", () => {
+    it("should return empty clusters for empty markers array", () => {
+      const input = {
+        markers: [],
+        map: {} as google.maps.Map,
+        mapCanvasProjection: {} as google.maps.MapCanvasProjection,
+      };
+
+      const result = algorithm.calculate(input);
+
+      expect(result).toEqual({ clusters: [], changed: true });
+      expect(mockSuperCalculate).not.toHaveBeenCalled();
+    });
+
+    it("should delegate to parent calculate for non-empty markers", () => {
+      const expectedOutput = { clusters: [{}], changed: false };
+      mockSuperCalculate.mockReturnValue(expectedOutput);
+
+      const input = {
+        markers: [{} as google.maps.Marker],
+        map: {} as google.maps.Map,
+        mapCanvasProjection: {} as google.maps.MapCanvasProjection,
+      };
+
+      const result = algorithm.calculate(input);
+
+      expect(result).toEqual(expectedOutput);
+      expect(mockSuperCalculate).toHaveBeenCalledWith(input);
+    });
+  });
+});


### PR DESCRIPTION
This is a stopgap fix for issue #362 and upstream issue #1129.

The upstream library fixed this bug for SuperClusterAlgorithm in PR #1014, but forgot to apply the same fix to SuperClusterViewportAlgorithm.

This wrapper adds the same empty markers check that was merged upstream, preventing the "Cannot read properties of undefined (reading 'range')" error when MarkerCluster is used with no markers.

Fixes #362
Related: googlemaps/js-markerclusterer#1129