### PR TITLE
Fix: Warnings appear in the chrome developer console

### DIFF
--- a/src/components/AdvancedMarker.vue
+++ b/src/components/AdvancedMarker.vue
@@ -82,7 +82,7 @@ export default defineComponent({
             content: hasCustomSlotContent.value
               ? markerRef.value
               : pinOptions.value
-                ? new PinElement(pinOptions.value).element
+                ? new PinElement(pinOptions.value)
                 : content,
             ...otherOptions,
           });
@@ -95,7 +95,7 @@ export default defineComponent({
           if (hasCustomSlotContent.value) {
             options.value.content = markerRef.value;
           } else if (pinOptions.value) {
-            options.value.content = new PinElement(pinOptions.value).element;
+            options.value.content = new PinElement(pinOptions.value);
           }
 
           marker.value = markRaw(new AdvancedMarkerElement(options.value));

--- a/src/components/AdvancedMarker.vue
+++ b/src/components/AdvancedMarker.vue
@@ -29,7 +29,9 @@ export interface IAdvancedMarkerExposed {
   marker: Ref<google.maps.marker.AdvancedMarkerElement | undefined>;
 }
 
-export const markerEvents = ["click", "drag", "dragend", "dragstart", "gmp-click"];
+const legacyClickEventName = "click";
+const newClickEventName = "gmp-click";
+export const markerEvents = ["drag", "dragend", "dragstart", newClickEventName];
 
 export default defineComponent({
   name: "AdvancedMarker",
@@ -43,7 +45,7 @@ export default defineComponent({
       required: false,
     },
   },
-  emits: markerEvents,
+  emits: [...markerEvents, legacyClickEventName],
   setup(props, { emit, expose, slots }) {
     const markerRef = ref<HTMLElement>();
     const hasCustomSlotContent = computed(() => slots.content?.().some((vnode) => vnode.type !== Comment));
@@ -107,7 +109,11 @@ export default defineComponent({
           }
 
           markerEvents.forEach((event) => {
-            marker.value?.addListener(event, (e: unknown) => emit(event, e));
+            marker.value?.addListener(event, (e: unknown) => {
+              emit(event, e);
+              // preserve backward compatibility for "click" event
+              if (event === newClickEventName) emit(legacyClickEventName, e);
+            });
           });
         }
       },

--- a/src/components/__tests__/InfoWindow.spec.ts
+++ b/src/components/__tests__/InfoWindow.spec.ts
@@ -358,16 +358,18 @@ describe("InfoWindow Component", () => {
       const infoWindow = infoWindows[0];
 
       const advancedMarkerAddListenerCalls = (advancedMarker.addListener as jest.Mock).mock.calls;
-      const advancedMarkerClickListeners = advancedMarkerAddListenerCalls.filter(
-        ([eventType]) => eventType === "click"
-      );
-      expect(advancedMarkerClickListeners).toHaveLength(2);
+
+      // AdvancedMarker registers "gmp-click" (not "click"), InfoWindow registers "click" on the anchor
+      const gmpClickListeners = advancedMarkerAddListenerCalls.filter(([eventType]) => eventType === "gmp-click");
+      const clickListeners = advancedMarkerAddListenerCalls.filter(([eventType]) => eventType === "click");
+      expect(gmpClickListeners).toHaveLength(1);
+      expect(clickListeners).toHaveLength(1);
 
       // When anchor is present, InfoWindow doesn't open immediately
       expect(infoWindow.open).not.toHaveBeenCalled();
 
-      // Simulate marker click to open InfoWindow
-      advancedMarkerClickListeners[1][1](); // Trigger the InfoWindow click listener
+      // Simulate marker click to open InfoWindow (InfoWindow's click listener)
+      clickListeners[0][1]();
       expect(infoWindow.open).toHaveBeenCalledTimes(1);
       expect(infoWindow.open).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -412,11 +414,14 @@ describe("InfoWindow Component", () => {
 
       await nextTick();
 
-      // Expect 2 click listeners per marker: one from AdvancedMarker's own events, one from InfoWindow
+      // AdvancedMarker registers "gmp-click", InfoWindow registers "click" on the anchor
       const markers = getAdvancedMarkerMocks();
       markers.forEach((marker) => {
-        const clickListeners = (marker.addListener as jest.Mock).mock.calls.filter(([event]) => event === "click");
-        expect(clickListeners).toHaveLength(2);
+        const addListenerCalls = (marker.addListener as jest.Mock).mock.calls;
+        const gmpClickListeners = addListenerCalls.filter(([event]) => event === "gmp-click");
+        const clickListeners = addListenerCalls.filter(([event]) => event === "click");
+        expect(gmpClickListeners).toHaveLength(1);
+        expect(clickListeners).toHaveLength(1);
       });
     });
   });


### PR DESCRIPTION
Details in the issue. 

Issue #371 

Warnings appear in the chrome developer console, when the page is first loaded with Advanced Marker.
```
<gmp-pin>: The `element` property is deprecated. Please use the PinElement directly
<gmp-advanced-marker>: Please use addEventListener('gmp-click', ...) instead of addEventListener('click', ...).
```

The fix for the addEventListener warning was a little more involved that I was hoping for initially. 