### PR TITLE
fix: use gmp-click for InfoWindow anchor listener on AdvancedMarkerElement

### DIFF
--- a/src/components/InfoWindow.vue
+++ b/src/components/InfoWindow.vue
@@ -23,6 +23,10 @@ import {
 import equal from "fast-deep-equal";
 import { apiSymbol, mapSymbol, markerSymbol } from "../shared/index";
 
+function getAnchorClickEvent(anchor: google.maps.Marker | google.maps.marker.AdvancedMarkerElement): string {
+  return anchor instanceof google.maps.marker.AdvancedMarkerElement ? "gmp-click" : "click";
+}
+
 export interface IInfoWindowExposed {
   infoWindow: Ref<google.maps.InfoWindow | undefined>;
   open: (opts?: google.maps.InfoWindowOpenOptions) => void;
@@ -109,7 +113,7 @@ export default defineComponent({
 
               // Set up initial anchor click listener
               if (anchor.value) {
-                anchorClickListener = anchor.value.addListener("click", () => open());
+                anchorClickListener = anchor.value.addListener(getAnchorClickEvent(anchor.value), () => open());
               }
 
               if (!anchor.value || internalVal) {
@@ -143,7 +147,7 @@ export default defineComponent({
 
           // Set up new listener
           if (newAnchor) {
-            anchorClickListener = newAnchor.addListener("click", () => open());
+            anchorClickListener = newAnchor.addListener(getAnchorClickEvent(newAnchor), () => open());
           }
         },
         {

--- a/src/components/__tests__/InfoWindow.spec.ts
+++ b/src/components/__tests__/InfoWindow.spec.ts
@@ -359,17 +359,15 @@ describe("InfoWindow Component", () => {
 
       const advancedMarkerAddListenerCalls = (advancedMarker.addListener as jest.Mock).mock.calls;
 
-      // AdvancedMarker registers "gmp-click" (not "click"), InfoWindow registers "click" on the anchor
+      // Both AdvancedMarker and InfoWindow register "gmp-click" on AdvancedMarkerElement anchors
       const gmpClickListeners = advancedMarkerAddListenerCalls.filter(([eventType]) => eventType === "gmp-click");
-      const clickListeners = advancedMarkerAddListenerCalls.filter(([eventType]) => eventType === "click");
-      expect(gmpClickListeners).toHaveLength(1);
-      expect(clickListeners).toHaveLength(1);
+      expect(gmpClickListeners).toHaveLength(2);
 
       // When anchor is present, InfoWindow doesn't open immediately
       expect(infoWindow.open).not.toHaveBeenCalled();
 
-      // Simulate marker click to open InfoWindow (InfoWindow's click listener)
-      clickListeners[0][1]();
+      // Simulate marker click to open InfoWindow (InfoWindow's gmp-click listener)
+      gmpClickListeners[1][1]();
       expect(infoWindow.open).toHaveBeenCalledTimes(1);
       expect(infoWindow.open).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -414,14 +412,12 @@ describe("InfoWindow Component", () => {
 
       await nextTick();
 
-      // AdvancedMarker registers "gmp-click", InfoWindow registers "click" on the anchor
+      // Both AdvancedMarker and InfoWindow register "gmp-click" on AdvancedMarkerElement anchors
       const markers = getAdvancedMarkerMocks();
       markers.forEach((marker) => {
         const addListenerCalls = (marker.addListener as jest.Mock).mock.calls;
         const gmpClickListeners = addListenerCalls.filter(([event]) => event === "gmp-click");
-        const clickListeners = addListenerCalls.filter(([event]) => event === "click");
-        expect(gmpClickListeners).toHaveLength(1);
-        expect(clickListeners).toHaveLength(1);
+        expect(gmpClickListeners).toHaveLength(2);
       });
     });
   });


### PR DESCRIPTION
## Summary

- InfoWindow registered a deprecated `click` listener on AdvancedMarkerElement anchors, producing a console warning: `Please use addEventListener('gmp-click', ...) instead of addEventListener('click', ...)`
- Added `getAnchorClickEvent()` helper that uses `instanceof` to pick `gmp-click` for AdvancedMarkerElement or `click` for legacy Marker
- Updated both anchor listener call sites in InfoWindow.vue

Follow-up to PR #372 which fixed the same deprecation in AdvancedMarker.vue but missed InfoWindow.vue.

## Test plan

- [x] All 177 existing tests pass (including updated InfoWindow anchor integration tests)
- [x] Verified in browser: zero deprecation warnings with AdvancedMarker + InfoWindow + pinOptions

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)