### PR TITLE
fix: prevent trailing debounce after MarkerCluster.destroy() (#376)

### DIFF
--- a/src/components/DebouncedMarkerClusterer.ts
+++ b/src/components/DebouncedMarkerClusterer.ts
@@ -1,6 +1,8 @@
 import { MarkerClusterer, MarkerClustererOptions } from "@googlemaps/markerclusterer";
 import debounce from "lodash-es/debounce";
 
+type RenderFn = (() => void) & { cancel: () => void };
+
 /**
  * MarkerClusterer with debounced rendering for batch operations.
  *
@@ -9,7 +11,7 @@ import debounce from "lodash-es/debounce";
  * This provides immediate visual feedback while still batching rapid updates.
  */
 export class DebouncedMarkerClusterer extends MarkerClusterer {
-  private readonly debouncedRender: ReturnType<typeof debounce>;
+  private debouncedRender: RenderFn;
 
   constructor(options: MarkerClustererOptions, debounceDelay = 10) {
     super(options);
@@ -66,7 +68,17 @@ export class DebouncedMarkerClusterer extends MarkerClusterer {
     super.render();
   }
 
+  /**
+   * Cancels any pending debounced render and replaces `debouncedRender` with a
+   * no-op so that calls arriving after destroy (e.g. `removeMarker` triggered
+   * by child components unmounting after `MarkerCluster.onBeforeUnmount`) cannot
+   * restart the debounce. Without this, a trailing `setTimeout` fires later and
+   * crashes inside `MarkerClusterer.render()` if the Maps API has been torn
+   * down. See issue #376.
+   */
   destroy(): void {
     this.debouncedRender.cancel();
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    this.debouncedRender = Object.assign(() => {}, { cancel: () => {} });
   }
 }

--- a/src/components/__tests__/DebouncedMarkerClusterer.spec.ts
+++ b/src/components/__tests__/DebouncedMarkerClusterer.spec.ts
@@ -117,5 +117,25 @@ describe("DebouncedMarkerClusterer", () => {
       expect(mockDebouncedRender.cancel).toHaveBeenCalled();
       expect(mockRender).not.toHaveBeenCalled();
     });
+
+    // Issue #376: parent-first onBeforeUnmount lets child markers call
+    // removeMarker() after MarkerCluster has already destroyed the clusterer.
+    // Those calls used to restart the debounce, and the trailing setTimeout
+    // would fire into a torn-down Maps API and throw inside
+    // `MarkerClusterer.render()`. After destroy, marker ops must not be able
+    // to invoke the original debounced render at all.
+    it("post-destroy marker ops must not invoke the debounced render (regression: issue #376)", () => {
+      clusterer.destroy();
+      mockDebouncedRender.mockClear();
+
+      clusterer.removeMarker(mockMarker);
+      clusterer.addMarker(mockMarker);
+      clusterer.removeMarkers([mockMarker]);
+      clusterer.addMarkers([mockMarker]);
+      clusterer.clearMarkers();
+
+      expect(mockDebouncedRender).not.toHaveBeenCalled();
+      expect(mockRender).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #376. `DebouncedMarkerClusterer.destroy()` previously only cancelled the pending timer. Vue's parent-first `onBeforeUnmount` means child markers' `removeMarker()` calls land *after* `destroy()` and were restarting the debounce. The trailing `setTimeout` then fired into a torn-down Maps API and threw `TypeError: Right-hand side of 'instanceof' is not an object` inside `MarkerClusterer.render()`.
- `destroy()` now also swaps `debouncedRender` for a no-op so post-destroy `addMarker`/`removeMarker`/etc. cannot restart the debounce.
- Field type narrowed from `ReturnType<typeof debounce>` to a structural `(() => void) & { cancel: () => void }` (only the surface the class actually uses); `readonly` removed to allow the swap.
- Reproduces with `Marker`, `AdvancedMarker`, and `CustomMarker` children — the marker type is irrelevant. Approach taken from the issue reporter @JoseGoncalves with TS-safe adjustments.

## Test plan
- [x] New regression test verifies post-destroy `addMarker`/`removeMarker`/`addMarkers`/`removeMarkers`/`clearMarkers` do not invoke the debounced render (fails on un-fixed code, passes with fix)
- [x] `npx jest` — 178/178 pass
- [x] `vue-tsc --noEmit` against `tsconfig.build.json` and `tsconfig.json` — clean
- [x] `eslint` — clean
- [x] Manual playground repro via Playwright across `Marker`/`AdvancedMarker`/`CustomMarker` — confirmed 0 errors after fix; reliably reproduced before

🤖 Generated with [Claude Code](https://claude.com/claude-code)