### PR TITLE
test: fix coverage line numbers via source-map handling

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: "jsdom",
   moduleFileExtensions: ["js", "ts", "vue", "json"],
   transform: {
-    "^.+\\.vue$": "@vue/vue3-jest",
+    "^.+\\.vue$": "<rootDir>/tests/vue-jest-transformer.js",
     "^.+\\.tsx?$": [
       "ts-jest",
       {
@@ -27,12 +27,15 @@ module.exports = {
     "!src/shims-*.ts",
     "!src/themes/**",
   ],
+  // Floors sit ~3-4 pts below actuals (branches 86.4 / functions 95.4 / lines 98.3 /
+  // statements 97.9). Raised after the source-map fix made coverage accurate; the old
+  // floors (72/88/88/85) compensated for under-reported coverage from broken .vue maps.
   coverageThreshold: {
     global: {
-      branches: 72,
-      functions: 88,
-      lines: 88,
-      statements: 85,
+      branches: 82,
+      functions: 92,
+      lines: 95,
+      statements: 94,
     },
   },
   coverageReporters: ["text", "json", "html", "lcov"],

--- a/tests/vue-jest-transformer.js
+++ b/tests/vue-jest-transformer.js
@@ -1,0 +1,32 @@
+/**
+ * Thin wrapper around @vue/vue3-jest that ensures the source map is returned
+ * as a parsed object instead of a JSON string. Istanbul (used by Jest for
+ * coverage) expects an object; when it receives a string the coverage report
+ * line numbers are wrong because Istanbul cannot remap them to the original
+ * source positions.
+ *
+ * @vue/vue3-jest returns `map` as a string (see its lib/process.js, which ends
+ * with `map: output.map.toString()`). This is the broken-coverage-line-numbers
+ * symptom tracked upstream in https://github.com/vuejs/vue-jest/issues/514
+ * (still open; the repo is effectively unmaintained, so do NOT remove this
+ * wrapper expecting an upstream fix — verify against a real coverage run first).
+ */
+const vueJest = require("@vue/vue3-jest");
+
+module.exports = {
+  process(src, filename, config) {
+    const result = vueJest.process(src, filename, config);
+
+    if (result && typeof result.map === "string") {
+      try {
+        result.map = JSON.parse(result.map);
+      } catch {
+        // If parsing fails, drop the map so coverage falls back gracefully
+        result.map = undefined;
+      }
+    }
+
+    return result;
+  },
+};
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,12 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    // Required for accurate Jest coverage line numbers. @vue/vue3-jest reads
+    // this root config when compiling SFC <script> blocks, and ts-jest merges
+    // it for .ts files; without it Istanbul maps coverage to compiled output.
+    // Inert for the build (emitDeclarationOnly above). See tests/vue-jest-transformer.js.
+    "sourceMap": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
@vue/vue3-jest returns the SFC source map as a JSON string, which Istanbul silently ignores (it expects an object), so .vue coverage was mapped to compiled-output positions — wildly wrong line numbers and under-reported coverage. Wrap the transformer to parse map -> object, and enable sourceMap in the root tsconfig so vue3-jest emits proper maps for <script> blocks (and ts-jest does the same for .ts files).

With accurate coverage, the global thresholds (previously lowered to mask the under-reporting) are raised to sit ~3-4 pts below real values: branches 72->82, functions 88->92, lines 88->95, statements 85->94.

Upstream: https://github.com/vuejs/vue-jest/issues/514 (unmaintained)