### PR TITLE
fix: deep reactivity for components with an :options config prop

### DIFF
--- a/src/components/AdvancedMarker.vue
+++ b/src/components/AdvancedMarker.vue
@@ -23,6 +23,7 @@ import {
   type Ref,
 } from "vue";
 import { markerSymbol, apiSymbol, mapSymbol, markerClusterSymbol } from "../shared/index";
+import { cloneOptions } from "../utils/index";
 import equal from "fast-deep-equal";
 
 export interface IAdvancedMarkerExposed {
@@ -63,10 +64,17 @@ export default defineComponent({
       () => !!(markerCluster.value && api.value && marker.value instanceof google.maps.marker.AdvancedMarkerElement)
     );
 
+    // Snapshots of the last options we acted on, insulated from in-place
+    // mutation of the source, so deep changes to `options`/`pinOptions` are
+    // reliably detected (see cloneOptions).
+    let appliedOptions: google.maps.marker.AdvancedMarkerElementOptions | undefined;
+    let appliedPinOptions: google.maps.marker.PinElementOptions | undefined;
+
     watch(
       [map, options, pinOptions, markerRef],
-      async (_, [oldMap, oldOptions, oldPinOptions, oldMarkerRef]) => {
-        const hasOptionChange = !equal(options.value, oldOptions) || !equal(pinOptions.value, oldPinOptions);
+      async (_, [oldMap, , , oldMarkerRef]) => {
+        const hasOptionChange =
+          !appliedOptions || !equal(options.value, appliedOptions) || !equal(pinOptions.value, appliedPinOptions);
         const hasMarkerRefChange = markerRef.value !== oldMarkerRef;
         const hasChanged = hasOptionChange || hasMarkerRefChange || map.value !== oldMap;
 
@@ -84,8 +92,8 @@ export default defineComponent({
             content: hasCustomSlotContent.value
               ? markerRef.value
               : pinOptions.value
-                ? new PinElement(pinOptions.value)
-                : content,
+              ? new PinElement(pinOptions.value)
+              : content,
             ...otherOptions,
           });
 
@@ -116,10 +124,14 @@ export default defineComponent({
             });
           });
         }
+
+        appliedOptions = cloneOptions(options.value);
+        appliedPinOptions = cloneOptions(pinOptions.value);
       },
       {
         immediate: true,
         flush: "post", // Ensure DOM updates happen before this watcher runs
+        deep: true,
       }
     );
 

--- a/src/components/HeatmapLayer.ts
+++ b/src/components/HeatmapLayer.ts
@@ -1,6 +1,7 @@
 import { defineComponent, PropType, ref, inject, watch, markRaw, onBeforeUnmount } from "vue";
 import equal from "fast-deep-equal";
 import { mapSymbol, apiSymbol } from "../shared/index";
+import { cloneOptions } from "../utils/index";
 
 type HeatmapLayerOptions = google.maps.visualization.HeatmapLayerOptions;
 
@@ -26,10 +27,15 @@ export default defineComponent({
     const map = inject(mapSymbol, ref());
     const api = inject(apiSymbol, ref());
 
+    // Snapshot of the last options we acted on, insulated from in-place
+    // mutation of the source, so deep changes to `options` are reliably
+    // detected (see cloneOptions).
+    let appliedOptions: ExtendedHeatmapLayerOptions | undefined;
+
     watch(
       [map, () => props.options],
-      ([_, options], [oldMap, oldOptions]) => {
-        const hasChanged = !equal(options, oldOptions) || map.value !== oldMap;
+      ([_, options], [oldMap]) => {
+        const hasChanged = !appliedOptions || !equal(options, appliedOptions) || map.value !== oldMap;
 
         if (map.value && api.value && hasChanged) {
           let opts: HeatmapLayerOptions;
@@ -72,9 +78,11 @@ export default defineComponent({
               })
             );
           }
+
+          appliedOptions = cloneOptions(options);
         }
       },
-      { immediate: true }
+      { immediate: true, deep: true }
     );
 
     onBeforeUnmount(() => {

--- a/src/components/InfoWindow.vue
+++ b/src/components/InfoWindow.vue
@@ -22,6 +22,7 @@ import {
 } from "vue";
 import equal from "fast-deep-equal";
 import { apiSymbol, mapSymbol, markerSymbol } from "../shared/index";
+import { cloneOptions } from "../utils/index";
 
 function getAnchorClickEvent(anchor: google.maps.Marker | google.maps.marker.AdvancedMarkerElement): string {
   return anchor instanceof google.maps.marker.AdvancedMarkerElement ? "gmp-click" : "click";
@@ -89,11 +90,16 @@ export default defineComponent({
       }
     };
 
+    // Snapshot of the last options we acted on, insulated from in-place
+    // mutation of the source, so deep changes to `options` are reliably
+    // detected (see cloneOptions).
+    let appliedOptions: google.maps.InfoWindowOptions | undefined;
+
     onMounted(() => {
       watch(
         [map, () => props.options],
-        ([_, options], [oldMap, oldOptions]) => {
-          const hasChanged = !equal(options, oldOptions) || map.value !== oldMap;
+        ([_, options], [oldMap]) => {
+          const hasChanged = !appliedOptions || !equal(options, appliedOptions) || map.value !== oldMap;
 
           if (map.value && api.value && hasChanged) {
             if (infoWindow.value) {
@@ -125,11 +131,14 @@ export default defineComponent({
               });
               infoWindow.value?.addListener("closeclick", () => updateVModel(false));
             }
+
+            appliedOptions = cloneOptions(options);
           }
         },
         {
           immediate: true,
           flush: "post",
+          deep: true,
         }
       );
 

--- a/src/components/__tests__/AdvancedMarker.spec.ts
+++ b/src/components/__tests__/AdvancedMarker.spec.ts
@@ -172,6 +172,62 @@ describe("AdvancedMarker Component", () => {
       expect(advancedMarker.zIndex).toBe(newOptions.zIndex);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should update marker properties when a nested option is mutated in place (deep reactivity)", async () => {
+      const position = { lat: 37.774, lng: -122.414 };
+
+      const wrapper = mount(AdvancedMarker, {
+        props: { options: { position, title: "SF" } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const advancedMarker = getAdvancedMarkerMocks()[0];
+
+      // Reset the marker's observable state to a sentinel so the assertion only
+      // passes if the update path actually re-applies the options. (The mock
+      // stores the same `position` object reference, so asserting on it directly
+      // would pass even without an update.)
+      advancedMarker.title = "SENTINEL";
+
+      // The only change is the in-place nested mutation; `title` is unchanged.
+      position.lat = 45.0;
+      position.lng = -75.0;
+      await wrapper.setProps({ options: { position, title: "SF" } });
+
+      expect(advancedMarker.title).toBe("SF");
+      expect(advancedMarker.position).toEqual(position);
+    });
+
+    // Guards the dedup optimization: a fresh-but-structurally-identical options
+    // object must NOT re-run the update path (no redundant Object.assign / cluster churn).
+    it("should not re-apply options when a new but deeply-equal options object is passed (dedup)", async () => {
+      const wrapper = mount(AdvancedMarker, {
+        props: { options: { position: { lat: 37.774, lng: -122.414 }, title: "SF" } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const advancedMarker = getAdvancedMarkerMocks()[0];
+
+      // If the update path runs, Object.assign overwrites this back to "SF".
+      advancedMarker.title = "SENTINEL";
+
+      await wrapper.setProps({ options: { position: { lat: 37.774, lng: -122.414 }, title: "SF" } });
+
+      expect(advancedMarker.title).toBe("SENTINEL");
+    });
+
     it("should maintain same AdvancedMarker instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/AdvancedMarker.spec.ts
+++ b/src/components/__tests__/AdvancedMarker.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
+import { nextTick, reactive, ref } from "vue";
 import AdvancedMarker, { markerEvents, type IAdvancedMarkerExposed } from "../AdvancedMarker.vue";
 import { mockInstances, Map, AdvancedMarkerElement, PinElement } from "@googlemaps/jest-mocks";
 import { mapSymbol, apiSymbol, markerClusterSymbol } from "../../shared";
@@ -202,6 +202,35 @@ describe("AdvancedMarker Component", () => {
 
       expect(advancedMarker.title).toBe("SF");
       expect(advancedMarker.position).toEqual(position);
+    });
+
+    // Unlike the test above, this never re-assigns the prop: the reactive options
+    // object is mutated in place and the watcher must fire on its own. This pins
+    // the watcher's `deep: true` (the setProps-based tests fire the watcher via
+    // the prop reference change and would pass without it).
+    it("should update marker properties when a reactive options object is mutated in place without reassignment (deep reactivity)", async () => {
+      const options = reactive({ position: { lat: 37.774, lng: -122.414 }, title: "SF" });
+
+      mount(AdvancedMarker, {
+        props: { options },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const advancedMarker = getAdvancedMarkerMocks()[0];
+
+      // If the update path runs, Object.assign overwrites this back to "SF".
+      advancedMarker.title = "SENTINEL";
+
+      options.position.lat = 45.0;
+      await nextTick();
+
+      expect(advancedMarker.title).toBe("SF");
     });
 
     // Guards the dedup optimization: a fresh-but-structurally-identical options

--- a/src/components/__tests__/Circle.spec.ts
+++ b/src/components/__tests__/Circle.spec.ts
@@ -141,6 +141,30 @@ describe("Circle Component", () => {
       expect(circle.setOptions).toHaveBeenCalledWith(options);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const center = { lat: 45.0, lng: -75.0 };
+
+      const wrapper = mount(Circle, {
+        props: { options: { center, radius: 200 } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const circle = getCircleMocks()[0];
+
+      center.lat = 46.0;
+      await wrapper.setProps({ options: { center, radius: 200 } });
+
+      expect(circle.setOptions).toHaveBeenCalledTimes(1);
+      expect(circle.setOptions).toHaveBeenCalledWith(expect.objectContaining({ center }));
+    });
+
     it("should maintain same Circle instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/CustomMarker.spec.ts
+++ b/src/components/__tests__/CustomMarker.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
+import { nextTick, reactive, ref } from "vue";
 import CustomMarker from "../CustomMarker.vue";
 import { Map } from "@googlemaps/jest-mocks";
 import { mapSymbol, apiSymbol, markerClusterSymbol, customMarkerClassSymbol } from "../../shared";
@@ -204,6 +204,41 @@ describe("CustomMarker Component", () => {
 
       expect(customMarker.setOptions).toHaveBeenCalledTimes(1);
       expect(customMarker.setOptions).toHaveBeenCalledWith(expect.objectContaining({ position }));
+    });
+
+    // Unlike the test above, this never re-assigns the prop: the reactive options
+    // object is mutated in place and the watcher must fire on its own. This pins
+    // `deep: true` for CustomMarker's distinct topology — its options pass through
+    // a `computed` that spreads props.options, so a nested mutation does not
+    // invalidate the computed itself; only the watcher's deep traversal of the
+    // computed's value subscribes to the nested reactive properties.
+    it("should call setOptions when a reactive options object is mutated in place without reassignment (deep reactivity)", async () => {
+      const options = reactive({ position: { lat: 37.774, lng: -122.414 } });
+
+      mount(CustomMarker, {
+        props: { options },
+        slots: {
+          // eslint-disable-next-line quotes
+          default: '<div class="custom-content">Custom Marker Content</div>',
+        },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const customMarker = getCustomMarkerMocks()[0];
+
+      // Clear setOptions calls from initial creation (element ref settles).
+      customMarker.setOptions.mockClear();
+
+      options.position.lat = 45.0;
+      await nextTick();
+
+      expect(customMarker.setOptions).toHaveBeenCalledTimes(1);
     });
 
     // Guards the dedup optimization for CustomMarker specifically: its `options`

--- a/src/components/__tests__/CustomMarker.spec.ts
+++ b/src/components/__tests__/CustomMarker.spec.ts
@@ -175,6 +175,67 @@ describe("CustomMarker Component", () => {
       expect(customMarker.setOptions).toHaveBeenCalledWith(expect.objectContaining(options));
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const position = { lat: 37.774, lng: -122.414 };
+
+      const wrapper = mount(CustomMarker, {
+        props: { options: { position } },
+        slots: {
+          // eslint-disable-next-line quotes
+          default: '<div class="custom-content">Custom Marker Content</div>',
+        },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const customMarker = getCustomMarkerMocks()[0];
+
+      // Clear setOptions calls from initial creation (element ref changes)
+      customMarker.setOptions.mockClear();
+
+      position.lat = 45.0;
+      await wrapper.setProps({ options: { position } });
+
+      expect(customMarker.setOptions).toHaveBeenCalledTimes(1);
+      expect(customMarker.setOptions).toHaveBeenCalledWith(expect.objectContaining({ position }));
+    });
+
+    // Guards the dedup optimization for CustomMarker specifically: its `options`
+    // is a computed that injects the DOM `element` ref, so dedup must compare
+    // that non-plain value by identity (cloneOptions keeps it by reference). A
+    // fresh-but-structurally-identical options object must NOT re-apply.
+    it("should not call setOptions when a new but deeply-equal options object is passed (dedup)", async () => {
+      const wrapper = mount(CustomMarker, {
+        props: { options: { position: { lat: 37.774, lng: -122.414 } } },
+        slots: {
+          // eslint-disable-next-line quotes
+          default: '<div class="custom-content">Custom Marker Content</div>',
+        },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const customMarker = getCustomMarkerMocks()[0];
+
+      // Clear setOptions calls from initial creation (element ref settles).
+      customMarker.setOptions.mockClear();
+
+      await wrapper.setProps({ options: { position: { lat: 37.774, lng: -122.414 } } });
+
+      expect(customMarker.setOptions).not.toHaveBeenCalled();
+    });
+
     it("should maintain same CustomMarker instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/HeatmapLayer.spec.ts
+++ b/src/components/__tests__/HeatmapLayer.spec.ts
@@ -203,6 +203,55 @@ describe("HeatmapLayer Component", () => {
       expect(heatmapLayer.setOptions).toHaveBeenCalledWith(options);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const data = [{ lat: 40.7128, lng: -74.006 }];
+
+      const wrapper = mount(HeatmapLayer, {
+        props: { options: { data } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const heatmapLayer = getHeatmapLayerMocks()[0];
+
+      data.push({ lat: 40.7614, lng: -73.9776 });
+      await wrapper.setProps({ options: { data } });
+
+      expect(heatmapLayer.setOptions).toHaveBeenCalledTimes(1);
+      expect(heatmapLayer.setOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.arrayContaining([expect.any(google.maps.LatLng), expect.any(google.maps.LatLng)]),
+        })
+      );
+    });
+
+    // Guards the dedup optimization: a fresh-but-structurally-identical options
+    // object must NOT trigger a redundant setOptions.
+    it("should not call setOptions when a new but deeply-equal options object is passed (dedup)", async () => {
+      const wrapper = mount(HeatmapLayer, {
+        props: { options: { data: [{ lat: 40.7128, lng: -74.006 }], radius: 30 } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const heatmapLayer = getHeatmapLayerMocks()[0];
+
+      await wrapper.setProps({ options: { data: [{ lat: 40.7128, lng: -74.006 }], radius: 30 } });
+
+      expect(heatmapLayer.setOptions).not.toHaveBeenCalled();
+    });
+
     it("should maintain same HeatmapLayer instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/HeatmapLayer.spec.ts
+++ b/src/components/__tests__/HeatmapLayer.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
+import { nextTick, reactive, ref } from "vue";
 import HeatmapLayer from "../HeatmapLayer";
 import { Map } from "@googlemaps/jest-mocks";
 import { mapSymbol, apiSymbol } from "../../shared";
@@ -229,6 +229,32 @@ describe("HeatmapLayer Component", () => {
           data: expect.arrayContaining([expect.any(google.maps.LatLng), expect.any(google.maps.LatLng)]),
         })
       );
+    });
+
+    // Unlike the test above, this never re-assigns the prop: the reactive options
+    // object is mutated in place and the watcher must fire on its own. This pins
+    // the watcher's `deep: true` (the setProps-based tests fire the watcher via
+    // the prop reference change and would pass without it).
+    it("should call setOptions when a reactive options object is mutated in place without reassignment (deep reactivity)", async () => {
+      const options = reactive({ data: [{ lat: 40.7128, lng: -74.006 }] });
+
+      mount(HeatmapLayer, {
+        props: { options },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const heatmapLayer = getHeatmapLayerMocks()[0];
+
+      options.data.push({ lat: 40.7614, lng: -73.9776 });
+      await nextTick();
+
+      expect(heatmapLayer.setOptions).toHaveBeenCalledTimes(1);
     });
 
     // Guards the dedup optimization: a fresh-but-structurally-identical options

--- a/src/components/__tests__/InfoWindow.spec.ts
+++ b/src/components/__tests__/InfoWindow.spec.ts
@@ -194,6 +194,51 @@ describe("InfoWindow Component", () => {
       );
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const position = { lat: 45.0, lng: -75.0 };
+
+      const wrapper = mount(InfoWindow, {
+        props: { options: { position, maxWidth: 300 } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const infoWindow = getInfoWindowMocks()[0];
+
+      position.lat = 46.0;
+      await wrapper.setProps({ options: { position, maxWidth: 300 } });
+
+      expect(infoWindow.setOptions).toHaveBeenCalledTimes(1);
+      expect(infoWindow.setOptions).toHaveBeenCalledWith(expect.objectContaining({ position }));
+    });
+
+    // Guards the dedup optimization: a fresh-but-structurally-identical options
+    // object must NOT trigger a redundant setOptions.
+    it("should not call setOptions when a new but deeply-equal options object is passed (dedup)", async () => {
+      const wrapper = mount(InfoWindow, {
+        props: { options: { position: { lat: 45.0, lng: -75.0 }, maxWidth: 300 } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const infoWindow = getInfoWindowMocks()[0];
+
+      await wrapper.setProps({ options: { position: { lat: 45.0, lng: -75.0 }, maxWidth: 300 } });
+
+      expect(infoWindow.setOptions).not.toHaveBeenCalled();
+    });
+
     it("should maintain same InfoWindow instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/InfoWindow.spec.ts
+++ b/src/components/__tests__/InfoWindow.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
+import { nextTick, reactive, ref } from "vue";
 import InfoWindow, { infoWindowEvents } from "../InfoWindow.vue";
 import Marker from "../Marker";
 import AdvancedMarker from "../AdvancedMarker.vue";
@@ -216,6 +216,32 @@ describe("InfoWindow Component", () => {
 
       expect(infoWindow.setOptions).toHaveBeenCalledTimes(1);
       expect(infoWindow.setOptions).toHaveBeenCalledWith(expect.objectContaining({ position }));
+    });
+
+    // Unlike the test above, this never re-assigns the prop: the reactive options
+    // object is mutated in place and the watcher must fire on its own. This pins
+    // the watcher's `deep: true` (the setProps-based tests fire the watcher via
+    // the prop reference change and would pass without it).
+    it("should call setOptions when a reactive options object is mutated in place without reassignment (deep reactivity)", async () => {
+      const options = reactive({ position: { lat: 45.0, lng: -75.0 }, maxWidth: 300 });
+
+      mount(InfoWindow, {
+        props: { options },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const infoWindow = getInfoWindowMocks()[0];
+
+      options.position.lat = 46.0;
+      await nextTick();
+
+      expect(infoWindow.setOptions).toHaveBeenCalledTimes(1);
     });
 
     // Guards the dedup optimization: a fresh-but-structurally-identical options

--- a/src/components/__tests__/Marker.spec.ts
+++ b/src/components/__tests__/Marker.spec.ts
@@ -131,6 +131,30 @@ describe("Marker Component", () => {
       expect(marker.setOptions).toHaveBeenCalledWith(options);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const position = { lat: 45.0, lng: -75.0 };
+
+      const wrapper = mount(Marker, {
+        props: { options: { position } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const marker = getMarkerMocks()[0];
+
+      position.lat = 46.0;
+      await wrapper.setProps({ options: { position } });
+
+      expect(marker.setOptions).toHaveBeenCalledTimes(1);
+      expect(marker.setOptions).toHaveBeenCalledWith(expect.objectContaining({ position }));
+    });
+
     it("should maintain same Marker instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/Polygon.spec.ts
+++ b/src/components/__tests__/Polygon.spec.ts
@@ -152,6 +152,33 @@ describe("Polygon Component", () => {
       expect(polygon.setOptions).toHaveBeenCalledWith(options);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const paths = [
+        { lat: 40.748, lng: -73.986 },
+        { lat: 40.748, lng: -73.982 },
+      ];
+
+      const wrapper = mount(Polygon, {
+        props: { options: { paths } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const polygon = getPolygonMocks()[0];
+
+      paths.push({ lat: 40.751, lng: -73.982 });
+      await wrapper.setProps({ options: { paths } });
+
+      expect(polygon.setOptions).toHaveBeenCalledTimes(1);
+      expect(polygon.setOptions).toHaveBeenCalledWith(expect.objectContaining({ paths }));
+    });
+
     it("should maintain same Polygon instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/Polyline.spec.ts
+++ b/src/components/__tests__/Polyline.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { nextTick, ref } from "vue";
+import { nextTick, reactive, ref } from "vue";
 import Polyline from "../Polyline";
 import { mockInstances, Map } from "@googlemaps/jest-mocks";
 import { mapSymbol, apiSymbol, polylineEvents } from "../../shared";
@@ -176,6 +176,38 @@ describe("Polyline Component", () => {
 
       expect(polyline.setOptions).toHaveBeenCalledTimes(1);
       expect(polyline.setOptions).toHaveBeenCalledWith(expect.objectContaining({ path }));
+    });
+
+    // Unlike the test above, this never re-assigns the prop: the reactive options
+    // object is mutated in place and the watcher must fire on its own. This pins
+    // the watcher's `deep: true` (the setProps-based tests fire the watcher via
+    // the prop reference change and would pass without it).
+    it("should call setOptions when a reactive options object is mutated in place without reassignment (deep reactivity)", async () => {
+      const options = reactive({
+        path: [
+          { lat: 37.772, lng: -122.214 },
+          { lat: 21.291, lng: -157.821 },
+        ],
+        geodesic: true,
+      });
+
+      mount(Polyline, {
+        props: { options },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const polyline = getPolylineMocks()[0];
+
+      options.path.push({ lat: -18.142, lng: 178.431 });
+      await nextTick();
+
+      expect(polyline.setOptions).toHaveBeenCalledTimes(1);
     });
 
     // Guards the dedup optimization: a parent re-render that passes a fresh-but-

--- a/src/components/__tests__/Polyline.spec.ts
+++ b/src/components/__tests__/Polyline.spec.ts
@@ -148,6 +148,58 @@ describe("Polyline Component", () => {
       expect(polyline.setOptions).toHaveBeenCalledWith(options);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    // A nested array is mutated in place and the options object is handed back
+    // still referencing that same (now-mutated) array. Shallow change detection
+    // misses this because the old and new values share the mutated reference.
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const path = [
+        { lat: 37.772, lng: -122.214 },
+        { lat: 21.291, lng: -157.821 },
+      ];
+
+      const wrapper = mount(Polyline, {
+        props: { options: { path, geodesic: true } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const polyline = getPolylineMocks()[0];
+
+      path.push({ lat: -18.142, lng: 178.431 });
+      await wrapper.setProps({ options: { path, geodesic: true } });
+
+      expect(polyline.setOptions).toHaveBeenCalledTimes(1);
+      expect(polyline.setOptions).toHaveBeenCalledWith(expect.objectContaining({ path }));
+    });
+
+    // Guards the dedup optimization: a parent re-render that passes a fresh-but-
+    // structurally-identical options object (e.g. an inline `:options="{...}"`
+    // literal) must NOT trigger a redundant setOptions.
+    it("should not call setOptions when a new but deeply-equal options object is passed (dedup)", async () => {
+      const wrapper = mount(Polyline, {
+        props: { options: { path: [{ lat: 37.772, lng: -122.214 }], geodesic: true } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const polyline = getPolylineMocks()[0];
+
+      await wrapper.setProps({ options: { path: [{ lat: 37.772, lng: -122.214 }], geodesic: true } });
+
+      expect(polyline.setOptions).not.toHaveBeenCalled();
+    });
+
     it("should maintain same Polyline instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/components/__tests__/Rectangle.spec.ts
+++ b/src/components/__tests__/Rectangle.spec.ts
@@ -143,6 +143,30 @@ describe("Rectangle Component", () => {
       expect(rectangle.setOptions).toHaveBeenCalledWith(options);
     });
 
+    // Regression test for https://github.com/inocan-group/vue3-google-map/issues/242
+    it("should call setOptions when a nested option is mutated in place (deep reactivity)", async () => {
+      const bounds = { north: 45, south: 40, east: -65, west: -70 };
+
+      const wrapper = mount(Rectangle, {
+        props: { options: { bounds } },
+        global: {
+          provide: {
+            [mapSymbol]: ref(mockMap),
+            [apiSymbol]: ref(mockApi),
+          },
+        },
+      });
+      await nextTick();
+
+      const rectangle = getRectangleMocks()[0];
+
+      bounds.north = 50;
+      await wrapper.setProps({ options: { bounds } });
+
+      expect(rectangle.setOptions).toHaveBeenCalledTimes(1);
+      expect(rectangle.setOptions).toHaveBeenCalledWith(expect.objectContaining({ bounds }));
+    });
+
     it("should maintain same Rectangle instance when options change", async () => {
       const wrapper = createWrapper();
       await nextTick();

--- a/src/composables/useSetupMapComponent.ts
+++ b/src/composables/useSetupMapComponent.ts
@@ -1,6 +1,7 @@
 import { watch, ref, Ref, inject, onBeforeUnmount, computed, markRaw } from "vue";
 import equal from "fast-deep-equal";
 import { apiSymbol, mapSymbol, markerClusterSymbol, customMarkerClassSymbol } from "../shared/index";
+import { cloneOptions } from "../utils/index";
 
 type ICtorKey = "Marker" | "Polyline" | "Polygon" | "Rectangle" | "Circle" | typeof customMarkerClassSymbol;
 
@@ -61,10 +62,15 @@ export const useSetupMapComponent = <T extends ICtorKey>(
       )
   );
 
+  // Snapshot of the last options we acted on, insulated from in-place mutation
+  // of the source. Compared against (instead of Vue's old value) so that deep
+  // changes — e.g. pushing to a nested `path` array — are reliably detected.
+  let appliedOptions: IComponentOptions<T> | undefined;
+
   watch(
     [map, options],
-    (_, [oldMap, oldOptions]) => {
-      const hasChanged = !equal(options.value, oldOptions) || map.value !== oldMap;
+    (_, [oldMap]) => {
+      const hasChanged = !appliedOptions || !equal(options.value, appliedOptions) || map.value !== oldMap;
 
       if (!map.value || !api.value || !hasChanged) return;
 
@@ -109,10 +115,13 @@ export const useSetupMapComponent = <T extends ICtorKey>(
           component.value?.addListener(event, (e: unknown) => emit(event, e));
         });
       }
+
+      appliedOptions = cloneOptions(options.value);
     },
     {
       immediate: true,
       flush: "post",
+      deep: true,
     }
   );
 

--- a/src/utils/__tests__/cloneOptions.spec.ts
+++ b/src/utils/__tests__/cloneOptions.spec.ts
@@ -1,0 +1,88 @@
+import { cloneOptions } from "../index";
+
+describe("cloneOptions", () => {
+  describe("deep-clones plain data", () => {
+    it("returns a structurally-equal but distinct object", () => {
+      const source = { a: 1, nested: { b: 2 }, list: [1, 2, 3] };
+      const clone = cloneOptions(source);
+
+      expect(clone).toEqual(source);
+      expect(clone).not.toBe(source);
+      expect(clone.nested).not.toBe(source.nested);
+      expect(clone.list).not.toBe(source.list);
+    });
+
+    it("clones arrays (including arrays of plain objects)", () => {
+      const source = [
+        { lat: 1, lng: 2 },
+        { lat: 3, lng: 4 },
+      ];
+      const clone = cloneOptions(source);
+
+      expect(clone).toEqual(source);
+      expect(clone).not.toBe(source);
+      expect(clone[0]).not.toBe(source[0]);
+    });
+
+    // The property the deep-reactivity fix relies on: a snapshot taken before an
+    // in-place mutation of the source must NOT observe that later mutation.
+    it("insulates the snapshot from later in-place mutation of the source", () => {
+      const source = { path: [{ lat: 1, lng: 2 }] };
+      const snapshot = cloneOptions(source);
+
+      source.path.push({ lat: 3, lng: 4 });
+      source.path[0].lat = 99;
+
+      expect(snapshot.path).toHaveLength(1);
+      expect(snapshot.path[0].lat).toBe(1);
+    });
+
+    it("does not let mutations of the clone leak back into the source", () => {
+      const source = { nested: { b: 2 } };
+      const clone = cloneOptions(source);
+
+      clone.nested.b = 99;
+
+      expect(source.nested.b).toBe(2);
+    });
+  });
+
+  describe("preserves non-plain values by reference", () => {
+    it("keeps class instances by reference (not deep-cloned)", () => {
+      class LatLng {
+        constructor(public lat: number, public lng: number) {}
+      }
+      const instance = new LatLng(1, 2);
+      const clone = cloneOptions({ position: instance });
+
+      expect(clone.position).toBe(instance);
+      expect(clone.position).toBeInstanceOf(LatLng);
+    });
+
+    it("keeps functions by reference", () => {
+      const fn = () => "x";
+      const clone = cloneOptions({ onClick: fn });
+
+      expect(clone.onClick).toBe(fn);
+    });
+
+    it("keeps DOM nodes by reference", () => {
+      const element = document.createElement("div");
+      const clone = cloneOptions({ element });
+
+      expect(clone.element).toBe(element);
+    });
+  });
+
+  describe("passes primitives and nullish values through", () => {
+    it.each([
+      ["a string", "hello"],
+      ["a number", 42],
+      ["a boolean", true],
+      ["null", null],
+      ["undefined", undefined],
+    ])("returns %s as-is", (_label, value) => {
+      expect(cloneOptions(value)).toBe(value);
+    });
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,38 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Snapshots the plain-data portions of an options object so it can be compared
+ * against a future value even if the source (or any of its nested arrays /
+ * objects) is mutated in place. This is what enables deep reactivity of
+ * `:options` props: without a snapshot insulated from in-place mutation, the
+ * change-detection `equal()` check would compare the live value against an old
+ * value that shares the same (already-mutated) nested references and therefore
+ * never detect a change.
+ *
+ * Plain objects and arrays are deep-cloned. Non-plain values — DOM nodes, class
+ * instances (e.g. `google.maps.LatLng`), and functions — are preserved by
+ * reference and compared by identity.
+ */
+export function cloneOptions<T>(options: T): T {
+  if (Array.isArray(options)) {
+    return options.map((item) => cloneOptions(item)) as unknown as T;
+  }
+
+  if (isPlainObject(options)) {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(options)) {
+      result[key] = cloneOptions(options[key]);
+    }
+    return result as unknown as T;
+  }
+
+  return options;
+}
+
 type ICustomMarkerInterface = google.maps.OverlayView & {
   getPosition(): google.maps.LatLng | null;
   getVisible(): boolean;


### PR DESCRIPTION
## Summary

Fixes #242. Mutating a nested value inside an `:options` object — e.g. pushing a coordinate to a `Polyline`'s `path` — did not update the map object, even after reassigning the options ref.

**Root cause:** the options watchers were shallow, and change detection compared the live options against Vue's *old value*. For an in-place nested mutation that old value is the same (already-mutated) reference, so `fast-deep-equal` never saw a difference; for the issue's reassign-sharing-the-mutated-array pattern, the shared nested array defeated the comparison the same way.

**Fix:** each options-driven watcher now:
- uses `deep: true`, so nested in-place mutations actually fire it (full depth is required — `deep: 1` wouldn't subscribe into nested arrays; `markRaw`'d Google objects are skipped by Vue's `traverse`, so it doesn't walk Map/marker internals);
- compares the live options against a **self-owned deep-clone snapshot** (`cloneOptions`) taken after each apply. The snapshot is insulated from later in-place mutation. Non-plain values (DOM nodes, `google.maps.LatLng` instances, functions) are preserved by reference.

The existing dedup of fresh-but-deeply-equal option objects is **retained**, so parent re-renders that pass inline `:options="{...}"` literals don't trigger redundant `setOptions` / cluster churn.

## Components covered

`Marker`, `Polyline`, `Polygon`, `Rectangle`, `Circle`, `CustomMarker` (via `useSetupMapComponent`), plus `AdvancedMarker`, `InfoWindow`, and `HeatmapLayer`. (`GoogleMap` is unaffected — it takes individual props, not an `:options` object.)

## Tests

- **Deep-reactivity** regression test per component: mutate a nested array/object in place, hand the same reference back via `setProps`, assert the update was applied. Verified each **fails without the fix**.
- **Dedup** tests (composable path via Polyline, AdvancedMarker, InfoWindow, HeatmapLayer, and CustomMarker for its DOM-`element`-by-identity path): a fresh-but-equal object must **not** re-apply. Verified each **fails if the dedup is removed**.
- **Unit test** for `cloneOptions` (deep-clone plain data, insulate snapshot from mutation, preserve non-plain values by reference).

204 tests pass; lint and `vue-tsc` typecheck clean.

## Why a hand-rolled `cloneOptions` instead of lodash

The snapshot must **deep-clone plain data but preserve non-plain values (DOM nodes, `google.maps.LatLng` instances, functions) by reference** — `fast-deep-equal` compares those by identity, so cloning a `LatLng` would break change detection. That rules out plain `cloneDeep`; the equivalent lodash tool is `cloneDeepWith(value, customizer)`, where the customizer returning non-plain values as-is *is* essentially the same handful of lines as this util.

The deciding factor is the **production bundle**, not convenience: `cloneDeepWith` drags in lodash's `_baseClone` internal graph — exactly the `lodash-es` surface this library is trying to shrink (the `Function('return this')()` polyfill that breaks strict-CSP deployments and trips Socket.dev's "dynamic code execution" flag). Adding a larger lodash import works against that direction. `structuredClone`/JSON are also out — they throw on / corrupt the DOM nodes and class instances options carry. So a ~15-line, zero-dependency, unit-tested helper with the exact preserve-by-reference semantics is the right call. (It intentionally doesn't handle Map/Set/Date/circular refs — none occur in Google Maps options, and option trees are acyclic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)